### PR TITLE
Polish homepage and services listings

### DIFF
--- a/src/components/ResultCard.astro
+++ b/src/components/ResultCard.astro
@@ -1,5 +1,6 @@
 ---
 export interface Props {
+  id?: string;
   title: string;
   service: string;
   before: string;
@@ -7,12 +8,22 @@ export interface Props {
   date?: string;
   caption?: string;
 }
-const { title, service, before, after, date = '', caption = '' } = Astro.props as Props;
-const id = `result-${title.replace(/\s+/g,'-').toLowerCase()}`;
+
+const { id, title, service, before, after, date = '', caption = '' } = Astro.props as Props;
+
+const slugify = (value: string) =>
+  value
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+    .trim();
+
+const dialogId = `result-${slugify(id ?? title) || 'item'}`;
 ---
 <figure class="result-card group overflow-hidden rounded-2xl shadow-sm bg-white">
   <div class="relative">
-    <button class="absolute right-3 top-3 z-10 btn-chip" data-open={id} aria-label={`Open before & after for ${service}`}>View</button>
+    <button class="absolute right-3 top-3 z-10 btn-chip" data-open={dialogId} aria-label={`Open before & after for ${service}`}>View</button>
     <div class="grid grid-cols-2">
       <div class="relative">
         <img src={before} alt={`Before — ${service}`} loading="lazy" decoding="async" class="w-full h-full object-cover" />
@@ -31,7 +42,7 @@ const id = `result-${title.replace(/\s+/g,'-').toLowerCase()}`;
     {caption && <div class="text-xs text-neutral-600 mt-1">{caption}</div>}
   </figcaption>
 
-  <dialog id={id} data-results>
+  <dialog id={dialogId} data-results>
     <div class="modal-card">
       <div class="modal-head">
         <div class="modal-title">{service}: {title}</div>

--- a/src/components/ResultsGrid.astro
+++ b/src/components/ResultsGrid.astro
@@ -2,6 +2,7 @@
 import ResultCard from '@/components/ResultCard.astro';
 
 export interface Item {
+  id?: string;
   title: string;
   service: string;
   before: string;
@@ -40,11 +41,25 @@ const {
       <div class="text-center text-neutral-500">Results coming soon.</div>
     ) : (
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-        {items.slice(0, limit).map((it) => <ResultCard title={it.title} service={it.service} before={it.before} after={it.after} date={it.date} caption={it.caption} />)}
+        {items
+          .slice(0, limit)
+          .map((it) => (
+            <ResultCard
+              id={it.id}
+              title={it.title}
+              service={it.service}
+              before={it.before}
+              after={it.after}
+              date={it.date}
+              caption={it.caption}
+            />
+          ))}
       </div>
     )}
-    <div class="text-center mt-8">
-      <a href={ctaHref} class="btn-neo">{ctaLabel}</a>
-    </div>
+    {items.length > 0 && (
+      <div class="text-center mt-8">
+        <a href={ctaHref} class="btn-neo">{ctaLabel}</a>
+      </div>
+    )}
   </div>
 </section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,13 +29,24 @@ const icons = {
 };
 
 const serviceMap = Object.fromEntries(services.map((s) => [s.slug, s.data.title]));
+
+const parseDate = (value?: string) => {
+  if (!value) return 0;
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+};
+
 const featuredResults = results
-  .filter((r) => r.data.featured)
+  .filter((r) => r.data.featured && r.data.consent !== false)
+  .sort((a, b) => parseDate(b.data.date) - parseDate(a.data.date))
   .map((r) => ({
+    id: r.id,
     title: r.data.title,
     service: serviceMap[r.data.serviceSlug] ?? 'Featured result',
     before: r.data.imageBefore,
     after: r.data.imageAfter,
+    date: r.data.date,
+    caption: r.data.notes,
   }));
 
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,8 +3,10 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
 import Section from '@/components/Section.astro';
 import ServiceCard from '@/components/ServiceCard.astro';
 import { getCollection } from 'astro:content';
+import ResultsGrid from '@/components/ResultsGrid.astro';
 
 const services = await getCollection('services');
+const results = await getCollection('results');
 
 const icons = {
   'neurotoxins':'syringe',
@@ -25,6 +27,16 @@ const icons = {
   'nefertiti-neck':'jawline',
   'specialty-treatments':'med-star'
 };
+
+const serviceMap = Object.fromEntries(services.map((s) => [s.slug, s.data.title]));
+const featuredResults = results
+  .filter((r) => r.data.featured)
+  .map((r) => ({
+    title: r.data.title,
+    service: serviceMap[r.data.serviceSlug] ?? 'Featured result',
+    before: r.data.imageBefore,
+    after: r.data.imageAfter,
+  }));
 
 
 const seo = {
@@ -58,7 +70,7 @@ const seo = {
             <a href="/services" class="btn-wire">See all services</a>
           </div>
           <div class="kpis">
-            <div class="kpi"><div class="v stars" aria-label="5 out of 5 stars" role="img" class="stars">★★★★★</div><div class="l">Client feedback</div></div>
+            <div class="kpi"><div class="v stars" aria-label="5 out of 5 stars" role="img">★★★★★</div><div class="l">Client feedback</div></div>
             <div class="kpi"><div class="v">Evidence‑led</div><div class="l">Protocols</div></div>
             <div class="kpi"><div class="v">Subtle</div><div class="l">Results</div></div>
           </div>
@@ -107,15 +119,16 @@ const seo = {
     <div class="mt-8 text-center"><a href="/services" class="btn-neo" aria-label="View all services">View all services</a></div>
 </Section>
 
-  
-  
+
+
 <!-- Approach (centered) -->
   <section id="approach" class="section section-muted">
-    <div class="container text-center max-w-6xl      <div class="card p-8">
+    <div class="container max-w-6xl text-center">
+      <div class="card p-8">
         <h3 class="text-2xl font-semibold tracking-tight">Our Approach</h3>
         <p class="text-muted mt-2">We start with your goals and timeline, then build a plan that balances efficacy, downtime, and budget.</p>
         <div class="kpis mt-6">
-          <div class="kpi"><div class="v stars" aria-label="5 out of 5 stars" role="img" class="stars">★★★★★</div><div class="l">Client feedback</div></div>
+          <div class="kpi"><div class="v stars" aria-label="5 out of 5 stars" role="img">★★★★★</div><div class="l">Client feedback</div></div>
           <div class="kpi"><div class="v">Evidence‑led</div><div class="l">Protocols</div></div>
           <div class="kpi"><div class="v">Subtle</div><div class="l">Results</div></div>
         </div>
@@ -124,39 +137,15 @@ const seo = {
   </section>
 
 
-  <!-- Results (Before/After placeholders) -->
-  <section id="results" class="section section-dark">
-    <div class="container text-center">
-      <h3 class="text-3xl sm:text-4xl font-semibold tracking-tight">Before & After</h3>
-      <p class="text-muted text-center mt-2 max-w-2xl mx-auto">Representative results — unretouched. Individual outcomes may vary.</p>
-      <div class="mt-8 grid md:grid-cols-3 gap-6">
-        <div class="space-y-2">
-  <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
-    <div class="ba-tile"></div>
-    <div class="ba-tile after"></div>
-  </div>
-  <div class="ba-midlabel">Before / After</div>
-</div>
-        <div class="space-y-2">
-  <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
-    <div class="ba-tile"></div>
-    <div class="ba-tile after"></div>
-  </div>
-  <div class="ba-midlabel">Before / After</div>
-</div>
-        <div class="space-y-2">
-  <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
-    <div class="ba-tile"></div>
-    <div class="ba-tile after"></div>
-  </div>
-  <div class="ba-midlabel">Before / After</div>
-</div>
-      </div>
-      <div class="mt-8">
-        <button class="btn btn-primary" type="button">+ Before & After</button>
-      </div>
-    </div>
-  </section>
+  <ResultsGrid
+    items={featuredResults}
+    title="Before & After"
+    subtitle="Representative results — unretouched. Individual outcomes may vary."
+    id="results"
+    limit={3}
+    ctaHref="/appointment"
+    ctaLabel="Book a consultation"
+  />
 
   <!-- Process (Stepper) -->
   <section id="process" class="section">

--- a/src/pages/services/index.astro
+++ b/src/pages/services/index.astro
@@ -1,6 +1,5 @@
 ---
 import BaseLayout from '@/layouts/BaseLayout.astro';
-import Section from '@/components/Section.astro';
 import ServiceCard from '@/components/ServiceCard.astro';
 import { getCollection } from 'astro:content';
 const entries = await getCollection('services');
@@ -44,7 +43,14 @@ const seo = {
         <a href="/appointment" class="btn btn-primary">Book</a>
       </div>
       <div class="mt-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-        {entries.map((entry) => ((e => <ServiceCard href={`/services/${e.slug}`} title={e.data.title} summary={e.data.summary} icon={icons[e.slug] ?? 'star'} />)}
+        {entries.map((entry) => (
+          <ServiceCard
+            href={`/services/${entry.slug}`}
+            title={entry.data.title}
+            summary={entry.data.summary}
+            icon={icons[entry.slug] ?? 'star'}
+          />
+        ))}
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- fix the homepage approach section markup and clean up KPI star badges
- replace the placeholder before-and-after tiles with a dynamic results grid fed from featured content
- repair the services index card loop so all services render correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4d5058ab083328a52f97bd454a2a9